### PR TITLE
Correctly initialize matrix in Object3D and FirstPersonCamera updateMatrix method

### DIFF
--- a/src/vkCraft/FirstPersonCamera.cpp
+++ b/src/vkCraft/FirstPersonCamera.cpp
@@ -101,7 +101,7 @@ void FirstPersonCamera::update(GLFWwindow *window, double time)
 
 void FirstPersonCamera::updateMatrix()
 {
-	matrix = glm::translate(glm::mat4(), position);
+	matrix = glm::translate(glm::mat4(1.0f), position);
 	matrix = glm::rotate(matrix, orientation.x, glm::vec3(0.0f, 1.0f, 0.0f));
 	matrix = glm::rotate(matrix, orientation.y, glm::vec3(1.0f, 0.0f, 0.0f));
 	matrix = glm::inverse(matrix);

--- a/src/vkCraft/Object3D.cpp
+++ b/src/vkCraft/Object3D.cpp
@@ -11,7 +11,7 @@ Object3D::Object3D()
 
 void Object3D::updateMatrix()
 {
-	matrix = glm::translate(glm::mat4(), position);
+	matrix = glm::translate(glm::mat4(1.0f), position);
 	matrix = glm::rotate(matrix, rotation.x, glm::vec3(1.0f, 0.0f, 0.0f));
 	matrix = glm::rotate(matrix, rotation.z, glm::vec3(0.0f, 0.0f, 1.0f));
 	matrix = glm::rotate(matrix, rotation.y, glm::vec3(0.0f, 1.0f, 0.0f));


### PR DESCRIPTION
The updateMatrix methods in Object3D and FirstPersonCamera create a new glm::mat4 matrix to transform on every call, but glm::mat4 is initialized with zeros by default. This creates invalid transformation matrices, leading to a complete rendering failure displaying nothing but the clear color (see #2). This pull request correctly initializes the matrices as identity matrices before performing transformations on them.